### PR TITLE
Feature: Fixing issues with the Joined runs test summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ $ xchtmlreport -r TestResults
 Report successfully created at ./index.html
 ```
 
+## Testing changes: 
+
+To test any changes made to the SDK locally:
+- Open the SDK folder with Xcode.
+- Click in the project target and select `Edit Scheme`.
+- In the `Run` category open the `Arguments` section.
+- In the `Arguments passed on Launch` list add a new argument with a valid path to an `.xcresult` file.
+- Make sure that the new argument is checked. 
+- Close the window and run.
+
 ### Multiple Result Bundle Path
 
 You can also pass multiple times the -r option.

--- a/Sources/XCTestHTMLReport/Classes/Models/JoinedRuns.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/JoinedRuns.swift
@@ -14,9 +14,12 @@ import XCResultKit
 struct JoinedRuns : HTML
 {
     let testGroupCollections: [TestGroupCollection]
-
+    
+    /// Returns the total number of tests inside every considered testGroup.
+    /// Fixes the problem with the "All" counter in the Joined runs summary
+    ///  For further context please check:  [PM-68](https://theknotww.atlassian.net/browse/PM-68)
     var numberOfTests : Int {
-        return testGroupCollections.reduce(0, { $0 + $1.testGroups.count })
+        return testGroupCollections.reduce(0) { $0 + $1.testGroups.count }
     }
 
     var numberOfPassedTests : Int {

--- a/Sources/XCTestHTMLReport/Classes/Models/JoinedRuns.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/JoinedRuns.swift
@@ -16,7 +16,7 @@ struct JoinedRuns : HTML
     let testGroupCollections: [TestGroupCollection]
 
     var numberOfTests : Int {
-        return allTestGroups.count
+        return testGroupCollections.reduce(0, { $0 + $1.testGroups.count })
     }
 
     var numberOfPassedTests : Int {

--- a/Sources/XCTestHTMLReport/Classes/Models/TestGroupCollection.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/TestGroupCollection.swift
@@ -25,6 +25,8 @@ struct TestGroupCollection: HTML {
         self.identifier = name
         self.duration = testGroups.reduce(0) { $0 + $1.duration }
         self.name = name
+        // Fixes the duplicate tests showing up in the Joined runs summary.
+        // For further context please check the following task: https://theknotww.atlassian.net/browse/PM-68
         self.testGroups = testGroups.filter { $0.name != name }
     }
 

--- a/Sources/XCTestHTMLReport/Classes/Models/TestGroupCollection.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/TestGroupCollection.swift
@@ -25,7 +25,7 @@ struct TestGroupCollection: HTML {
         self.identifier = name
         self.duration = testGroups.reduce(0) { $0 + $1.duration }
         self.name = name
-        self.testGroups = testGroups
+        self.testGroups = testGroups.filter { $0.name != name }
     }
 
     // PRAGMA MARK: - HTML


### PR DESCRIPTION
The Joined runs summary used to show the main test groups as repeated entries inside the test groups and flagged them as errors, this was also causing the total test count to be off. This is how is behaving now:
<img width="1294" alt="Screenshot 2022-09-12 at 17 15 48" src="https://user-images.githubusercontent.com/93128518/189938822-12146dab-85b2-4663-b593-b2e9f810bd33.png">

This is how it was behaving before the changes:
<img width="695" alt="Screenshot 2022-08-05 at 13 13 48" src="https://user-images.githubusercontent.com/93128518/189939513-12373641-2356-4042-b6ea-847d4d7668ab.png">

